### PR TITLE
cdn: implement uploads through pre-signed urls

### DIFF
--- a/Titanic.CDN/Models/AdminPresignUploadResponseModel.cs
+++ b/Titanic.CDN/Models/AdminPresignUploadResponseModel.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Titanic.CDN.Models;
+
+public class AdminPresignUploadResponseModel
+{
+    [JsonProperty("key")]
+    public string Key { get; set; } = null!;
+
+    [JsonProperty("url")]
+    public string Url { get; set; } = null!;
+
+    [JsonProperty("method")]
+    public string Method { get; set; } = null!;
+}

--- a/Titanic.CDN/Requests/PresignUploadRequest.cs
+++ b/Titanic.CDN/Requests/PresignUploadRequest.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Titanic.CDN.Models;
+
+namespace Titanic.CDN.Requests
+{
+    public class PresignUploadRequest : CDNRequest<AdminPresignUploadResponseModel>
+    {
+        public string ObjectKey { get; set; }
+        public string? ContentType { get; set; }
+
+        public PresignUploadRequest(string objectKey, string? contentType = null)
+        {
+            TitanicCDN.EscapeObjectKey(objectKey);
+            ObjectKey = objectKey;
+            ContentType = contentType;
+        }
+
+        protected override AdminPresignUploadResponseModel Execute(TitanicCDN cdn)
+        {
+            cdn.EnsureAccessKey();
+
+            Dictionary<string, string>? headers = null;
+            if (!string.IsNullOrEmpty(ContentType))
+                headers = new Dictionary<string, string> { ["Content-Type"] = ContentType! };
+
+            return cdn.Post<AdminPresignUploadResponseModel>($"/admin/files/{TitanicCDN.EscapeObjectKey(ObjectKey)}", headers);
+        }
+    }
+}

--- a/Titanic.CDN/TitanicCDN.cs
+++ b/Titanic.CDN/TitanicCDN.cs
@@ -88,7 +88,7 @@ namespace Titanic.CDN
         {
             Debug.Print("TitanicCDN: GET " + endpoint);
             string str = this._http.RequestString(HttpMethodType.GET, endpoint, null, headers);
-            
+
             T? obj = JsonConvert.DeserializeObject<T>(str, _settings);
             if (obj == null)
                 throw new Exception("Response had null content");
@@ -131,7 +131,33 @@ namespace Titanic.CDN
             Debug.Print("TitanicCDN: PUT " + endpoint);
             byte[] bytes = this._http.RequestBytes(HttpMethodType.PUT, endpoint, data, headers);
             string str = Encoding.UTF8.GetString(bytes);
-            
+
+            T? obj = JsonConvert.DeserializeObject<T>(str, _settings);
+            if (obj == null)
+                throw new Exception("Response had null content");
+
+            return obj;
+        }
+
+#if NET8_0_OR_GREATER
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026",
+            Justification = "The appropriate code is marked as untrimmed."
+        )]
+#endif
+        public T Post
+#if NET8_0_OR_GREATER
+            <[DynamicallyAccessedMembers(types)] T>
+#else
+            <T>
+#endif
+            (string endpoint, Dictionary<string, string>? headers = null)
+        {
+            Debug.Print("TitanicCDN: POST " + endpoint);
+            byte[] bytes = this._http.RequestBytes(HttpMethodType.POST, endpoint, (string?)null, headers);
+            string str = Encoding.UTF8.GetString(bytes);
+
             T? obj = JsonConvert.DeserializeObject<T>(str, _settings);
             if (obj == null)
                 throw new Exception("Response had null content");


### PR DESCRIPTION
Cloudflare has a very unfortunate and annoying 100 mb upload limit, and I was trying to circumvent this by using the pre-signed URLs that S3 offers. This pr just implements the endpoint to do exactly that. In the future we could probably make the upload more convenient, by adding a `Perform(...)` method to `AdminPresignUploadResponseModel`. However, this should do for now.